### PR TITLE
Add MemoryHub container and doc

### DIFF
--- a/docs/virtual_department.md
+++ b/docs/virtual_department.md
@@ -1,0 +1,49 @@
+# Virtual department memory guide
+
+This guide demonstrates connecting a hierarchy of agents to durable data
+stores with a small dependency‑injection container.
+
+## Storage tiers
+
+Information flows through several tiers of durability:
+
+1. **Context window** — transient, per model call.
+2. **Redis** — short‑lived cache used for minutes.
+3. **PostgreSQL** — drafts, status flags and checkpoints stored for days.
+4. **Vector database and object storage** — final artifacts and embeddings for long‑term storage.
+5. **Kafka** — append‑only audit log for the lifetime of the account.
+
+Each agent layer only interacts with the storage systems it needs.
+A micro agent only touches Redis, taskmasters read Redis and write to
+PostgreSQL, heads add the vector store and object storage, and the
+C‑level agent uses PostgreSQL and Kafka only.
+
+## MemoryHub container
+
+`MemoryHub` holds clients for all storage backends:
+
+```python
+from agents import MemoryHub
+
+hub = MemoryHub(redis_client, pg_session, vector_dao, obj_client, kafka_producer)
+```
+
+When building agents you pass this hub but expose only the relevant
+slice:
+
+```python
+from agents import (
+    build_micro_agent,
+    build_taskmaster,
+    build_head,
+    build_c_level,
+)
+
+micro = build_micro_agent("micro", some_tool, hub)
+taskmaster = build_taskmaster("tm", orchestrate, hub)
+head = build_head("head", plan_fn, hub)
+executive = build_c_level("ceo", approve_fn, hub)
+```
+
+Each build function attaches just the required clients in the agent's
+`memory` field.

--- a/examples/realtime/cli/demo.py
+++ b/examples/realtime/cli/demo.py
@@ -52,7 +52,7 @@ class NoUIDemo:
         # Audio output state for callback system
         self.output_queue: queue.Queue[Any] = queue.Queue(maxsize=10)  # Buffer more chunks
         self.interrupt_event = threading.Event()
-        self.current_audio_chunk: np.ndarray | None = None  # type: ignore
+        self.current_audio_chunk: np.ndarray | None = None
         self.chunk_position = 0
 
     def _output_callback(self, outdata, frames: int, time, status) -> None:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ plugins:
                     - models/index.md
                     - models/litellm.md
                 - config.md
+                - virtual_department.md
                 - visualization.md
                 - release.md
                 - Voice agents:
@@ -167,6 +168,7 @@ plugins:
                     - models/index.md
                     - models/litellm.md
                 - config.md
+                - virtual_department.md
                 - visualization.md
                 - 音声エージェント:
                     - voice/quickstart.md

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -40,7 +40,7 @@ from .items import (
     TResponseInputItem,
 )
 from .lifecycle import AgentHooks, RunHooks
-from .memory import Session, SQLiteSession
+from .memory import HubSlice, MemoryHub, Session, SQLiteSession
 from .model_settings import ModelSettings
 from .models.interface import Model, ModelProvider, ModelTracing
 from .models.openai_chatcompletions import OpenAIChatCompletionsModel
@@ -115,6 +115,13 @@ from .tracing import (
 )
 from .usage import Usage
 from .version import __version__
+from .virtual_department import (
+    DepartmentAgent,
+    build_c_level,
+    build_head,
+    build_micro_agent,
+    build_taskmaster,
+)
 
 
 def set_default_openai_key(key: str, use_for_tracing: bool = True) -> None:
@@ -213,6 +220,13 @@ __all__ = [
     "AgentHooks",
     "Session",
     "SQLiteSession",
+    "MemoryHub",
+    "HubSlice",
+    "DepartmentAgent",
+    "build_micro_agent",
+    "build_taskmaster",
+    "build_head",
+    "build_c_level",
     "RunContextWrapper",
     "TContext",
     "RunErrorDetails",

--- a/src/agents/memory/__init__.py
+++ b/src/agents/memory/__init__.py
@@ -1,3 +1,4 @@
+from .hub import HubSlice, MemoryHub
 from .session import Session, SQLiteSession
 
-__all__ = ["Session", "SQLiteSession"]
+__all__ = ["Session", "SQLiteSession", "MemoryHub", "HubSlice"]

--- a/src/agents/memory/hub.py
+++ b/src/agents/memory/hub.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class MemoryHub:
+    """Container for durable memory clients."""
+
+    redis: Any
+    """Redis client for short-lived caches."""
+
+    pg: Any
+    """PostgreSQL session or connection."""
+
+    vec: Any
+    """Vector store data access object."""
+
+    obj: Any
+    """Object storage client."""
+
+    kafka: Any
+    """Kafka producer for audit events."""
+
+    def micro_slice(self) -> HubSlice:
+        """Return the subset of the hub used by micro agents."""
+        return HubSlice(redis=self.redis)
+
+    def taskmaster_slice(self) -> HubSlice:
+        """Return the subset used by taskmaster agents."""
+        return HubSlice(redis=self.redis, pg=self.pg)
+
+    def head_slice(self) -> HubSlice:
+        """Return the subset used by head agents."""
+        return HubSlice(redis=self.redis, pg=self.pg, vec=self.vec, obj=self.obj)
+
+    def c_level_slice(self) -> HubSlice:
+        """Return the subset used by C-level agents."""
+        return HubSlice(pg=self.pg, kafka=self.kafka)
+
+
+@dataclass
+class HubSlice:
+    """A partial view of a :class:`MemoryHub`."""
+
+    redis: Any | None = None
+    pg: Any | None = None
+    vec: Any | None = None
+    obj: Any | None = None
+    kafka: Any | None = None

--- a/src/agents/virtual_department.py
+++ b/src/agents/virtual_department.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from .agent import Agent
+from .memory.hub import HubSlice, MemoryHub
+from .tool import function_tool
+
+
+@dataclass
+class DepartmentAgent(Agent[Any]):
+    """Agent instance with attached memory slice."""
+
+    memory: HubSlice | None = None
+
+
+def build_micro_agent(name: str, tool_fn: Callable[..., Any], hub: MemoryHub) -> DepartmentAgent:
+    """Create a micro agent with Redis-backed memory."""
+    return DepartmentAgent(name=name, tools=[function_tool(tool_fn)], memory=hub.micro_slice())
+
+
+def build_taskmaster(name: str, tool_fn: Callable[..., Any], hub: MemoryHub) -> DepartmentAgent:
+    """Create a taskmaster agent with Redis and PostgreSQL access."""
+    return DepartmentAgent(name=name, tools=[function_tool(tool_fn)], memory=hub.taskmaster_slice())
+
+
+def build_head(name: str, tool_fn: Callable[..., Any], hub: MemoryHub) -> DepartmentAgent:
+    """Create a head agent with access to object storage and the vector store."""
+    return DepartmentAgent(name=name, tools=[function_tool(tool_fn)], memory=hub.head_slice())
+
+
+def build_c_level(name: str, tool_fn: Callable[..., Any], hub: MemoryHub) -> DepartmentAgent:
+    """Create a C-level agent with PostgreSQL and Kafka access."""
+    return DepartmentAgent(name=name, tools=[function_tool(tool_fn)], memory=hub.c_level_slice())


### PR DESCRIPTION
## Summary
- document durable storage tiers for a virtual department
- implement `MemoryHub` container and helper builders
- expose new APIs from the package
- hook the doc into mkdocs navigation
- fix unused type ignore in demo example

## Testing
- `make format`
- `make lint`
- `make mypy`
- `OPENAI_API_KEY=dummy_key make tests`


------
https://chatgpt.com/codex/tasks/task_e_6879f86af5b48330b65afd09a508fd59